### PR TITLE
Fix class Async() to async_call instead of session.threadsafe_call

### DIFF
--- a/rplugin/python3/nvim_ipy/__init__.py
+++ b/rplugin/python3/nvim_ipy/__init__.py
@@ -85,7 +85,7 @@ class Async(object):
         self.wraps = wraps
 
     def __getattr__(self, name):
-        return partial(self.wraps.vim.session.threadsafe_call, getattr(self.wraps, name))
+        return partial(self.wraps.vim.async_call, getattr(self.wraps, name))
 
 class ExclusiveHandler(object):
     """Wrapper for buffering incoming messages from a asynchronous source.


### PR DESCRIPTION
python-client master removed vim.session API.

Thanks very amazing plugin!!!
Works perfectly in Intel® Distribution for Python :)