### PR TITLE
Fire autocommand on IPyConnect

### DIFF
--- a/rplugin/python3/nvim_ipy/__init__.py
+++ b/rplugin/python3/nvim_ipy/__init__.py
@@ -252,6 +252,7 @@ class IPythonPlugin(object):
     @neovim.function("IPyConnect", sync=True)
     def ipy_connect(self, args):
         self.configure()
+        self.vim.command(":doautocmd <nomodeline> User ipy-connect")
         # create buffer synchronously, as there is slight
         # racyness in seeing the correct current_buffer otherwise
         self.create_outbuf()


### PR DESCRIPTION
It would be useful if we were able to create mapping or set other options (such as omnifunc) only once IPyConnect is started. With this patch, an autocommand is fired as soon as IPyConnect is run, which allows the user to do just that.

For example,

    autocmd User ipy-connect call SetIPyOptions()
    function SetIPyOptions()
      map <silent> <CR> <Plug>(IPy-Run)
      set omnifunc=IPyOmniFunc
    endfunction

I hope this is the right place to fire it.