### PR TITLE
Add `IPyRunCell` function to execute a cell.

### DIFF
--- a/plugin/ipy.vim
+++ b/plugin/ipy.vim
@@ -4,6 +4,7 @@ command! -nargs=* IJulia :call IPyConnect("--kernel", "julia-0.4")
 
 nnoremap <Plug>(IPy-Run) :call IPyRun(getline('.'))<cr>
 vnoremap <Plug>(IPy-Run) :<c-u>call IPyRun(<SID>get_visual_selection())<cr>
+noremap <Plug>(IPyRunCell) :call IPyRunCell()<cr>
 inoremap <Plug>(IPy-Complete) <c-o>:<c-u>call IPyComplete()<cr>
 noremap <Plug>(IPy-WordObjInfo) :call IPyObjInfo(<SID>get_current_word(), 0)<cr>
 noremap <Plug>(IPy-Interrupt) :call IPyInterrupt()<cr>
@@ -45,6 +46,7 @@ let g:ipy_status = ""
 
 if g:nvim_ipy_perform_mappings
     map <silent> <F5>           <Plug>(IPy-Run)
+    map <leader>c <Plug>(IPy-Run-Cell)
     imap <silent> <C-F> <Plug>(IPy-Complete)
     map <silent> <F8> <Plug>(IPy-Interrupt)
     map <silent> <leader>? <Plug>(IPy-WordObjInfo)


### PR DESCRIPTION
I added wmvanvliet's [`wmvanvliet's run_cell`](https://github.com/wmvanvliet/vim-ipython) function, to emulate a cell mode.

The collection of lines is implemented in python which should be faster. Please check if I adjusted the code the right way, as I only tried to emulate your `ipy_run` function with his code and I actually don't know how neovim plug-ins work.

The cell separators should probably be refactored into a vimscript variable, to be configurable.