### PR TITLE
Add mapping to run entire buffer

### DIFF
--- a/plugin/ipy.vim
+++ b/plugin/ipy.vim
@@ -5,6 +5,7 @@ command! -nargs=* IJulia :call IPyConnect("--kernel", "julia-0.4")
 nnoremap <Plug>(IPy-Run) :call IPyRun(getline('.')."\n")<cr>
 vnoremap <Plug>(IPy-Run) :<c-u>call IPyRun(<SID>get_visual_selection())<cr>
 nnoremap <Plug>(IPy-RunCell) :<c-u>call IPyRunCell()<cr>
+nnoremap <Plug>(IPy-RunAll) :call IPyRun(join(getline(1, '$'), "\n"))<cr>
 inoremap <Plug>(IPy-Complete) <c-o>:<c-u>call IPyComplete()<cr>
 noremap <Plug>(IPy-WordObjInfo) :call IPyObjInfo(<SID>get_current_word(), 0)<cr>
 noremap <Plug>(IPy-Interrupt) :call IPyInterrupt()<cr>


### PR DESCRIPTION
A very small update I added one line to ipy.vim to create a mapping to run the entire buffer. I am a bit of a newbie to vim scripting so I'm unsure if I should have `<c-u>` at the front of the mapping and also whether `join()` is a good function to call on a list of all the lines in the buffer.