### PR TITLE
Add mapping to execute current word

### DIFF
--- a/plugin/ipy.vim
+++ b/plugin/ipy.vim
@@ -2,6 +2,7 @@ command! -nargs=* IPython :call IPyConnect(<f-args>)
 command! -nargs=* IPython2 :call IPyConnect("--kernel", "python2")
 command! -nargs=* IJulia :call IPyConnect("--kernel", "julia-0.4")
 
+nnoremap <Plug>(IPy-Word) <Cmd>call IPyRun(expand("<cword>"))<cr>
 nnoremap <Plug>(IPy-Run) <Cmd>call IPyRun(getline('.')."\n")<cr>
 vnoremap <Plug>(IPy-Run) :<c-u>call IPyRun(<SID>get_visual_selection())<cr>
 nnoremap <Plug>(IPy-RunCell) <Cmd>call IPyRunCell()<cr>


### PR DESCRIPTION
I just added a simple mapping to execute (run) the current word. This is useful for me when I want to print the value of a variable without all the details from introspection and without selecting the word. I think it only makes sense in normal mode.