### PR TITLE
Check if version & name are present in kernel info reply

### DIFF
--- a/rplugin/python3/nvim_ipy/__init__.py
+++ b/rplugin/python3/nvim_ipy/__init__.py
@@ -243,8 +243,15 @@ class IPythonPlugin(object):
 
         reply = self.waitfor(self.kc.kernel_info())
         c = reply['content']
-        lang = c['language_info']['name']
-        langver = c['language_info']['version']
+
+        lang = 'unknown'
+        langver = 'unknown'
+
+        if 'name' in c['language_info']:
+            lang = c['language_info']['name']
+
+        if 'version' in c['language_info']: 
+            langver = c['language_info']['version']
 
         banner = [ "nvim-ipy: Jupyter shell for Neovim"] if not has_previous else []
         try:

--- a/rplugin/python3/nvim_ipy/__init__.py
+++ b/rplugin/python3/nvim_ipy/__init__.py
@@ -244,14 +244,8 @@ class IPythonPlugin(object):
         reply = self.waitfor(self.kc.kernel_info())
         c = reply['content']
 
-        lang = 'unknown'
-        langver = 'unknown'
-
-        if 'name' in c['language_info']:
-            lang = c['language_info']['name']
-
-        if 'version' in c['language_info']: 
-            langver = c['language_info']['version']
+        lang = c['language_info'].get('name', 'unknown')
+        langver = c['language_info'].get('version', 'unknown')
 
         banner = [ "nvim-ipy: Jupyter shell for Neovim"] if not has_previous else []
         try:


### PR DESCRIPTION
Extremely simple change motivated by personal eagerness to communicate to spark magic kernel. The latter does not send `version` in `language_info` part of the Kernel Info response.

Taking it a bit further seems that the `version` is not a required item of `language_info`, so hopefully this would justify the contribution: https://jupyter-client.readthedocs.io/en/stable/wrapperkernels.html#MyKernel.language_info

Thank you so much @bfredl fo such a useful piece of software!