### PR TITLE
feat: add a notification when connected to kernel

### DIFF
--- a/rplugin/python3/nvim_ipy/__init__.py
+++ b/rplugin/python3/nvim_ipy/__init__.py
@@ -270,6 +270,8 @@ class IPythonPlugin(object):
         for i in range(len(banner)):
             self.buf.add_highlight('Comment', pos+i)
 
+        vim.exec_lua('vim.notify("Connected to kernel")')
+
         if self.do_filetype:
             # TODO: we might want to wrap this in a sync call
             # to avoid racyness with user interaction


### PR DESCRIPTION
I'm starting to try out this plugin and seems great so far. I got inspiration from this blogpost:
https://www.blog.gambitaccepted.com/2020/04/26/neovim-qtconsole-setup/

and am planning to similarly use nvim-ipy with `--no-window`. But in this case it would be nice to get a notification that the connection to the kernel occurs. This PR adds such a simple call, let me know if it seems okay.

(btw, I tried to call `vim.notify` directly but the python object did not have this attribute)